### PR TITLE
Add default number of comments to show on page

### DIFF
--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -42,7 +42,10 @@ function getMessage() {
   fetch('/data').then(response => response.json()).then((messages) => {
     console.log(messages);
     let html = '';
-    let numDisplay = getParameter("numComments", 10);
+    let numDisplay = getParameter("numComments");
+    if (numDisplay == null) {
+      numDisplay = 10; // Default value
+    }
     for (index = 0; index < messages.length && index < numDisplay; index++) {
       html += '<p>' + messages[index] + '</p><br/>';
     }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -44,7 +44,7 @@ function getMessage() {
     let html = '';
     let numDisplay = getParameter("numComments");
     if (numDisplay == null) {
-      numDisplay = 10; // Default value
+      numDisplay = 10;  // Default value.
     }
     for (index = 0; index < messages.length && index < numDisplay; index++) {
       html += '<p>' + messages[index] + '</p><br/>';


### PR DESCRIPTION
The comments wouldn't show up until you click on one of the buttons. Thus, this small change fixes that. If none of the number-of-comments-to-show buttons are clicked, then that number will be defaulted to 10.