### PR TITLE
Prevent possible HTML injection

### DIFF
--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -41,15 +41,20 @@ function addRandomGreeting() {
 function getMessage() {
   fetch('/data').then(response => response.json()).then((messages) => {
     console.log(messages);
-    let html = '';
+    let commentsDiv = document.createElement('div');
     let numDisplay = getParameter("numComments");
     if (numDisplay == null) {
       numDisplay = 10;  // Default value.
     }
     for (index = 0; index < messages.length && index < numDisplay; index++) {
-      html += '<p>' + messages[index] + '</p><br/>';
+      let comment = document.createElement('p');
+      let linebreak = document.createElement('br');
+      comment.textContent = messages[index];
+
+      commentsDiv.appendChild(comment);
+      commentsDiv.appendChild(linebreak);
     }
-    document.getElementById('display-comments').innerHTML = html;
+    document.getElementById('display-comments').appendChild(commentsDiv);
   });
 }
 


### PR DESCRIPTION
This is one of the features suggested at the end of the comments walkthrough. Previously, I used the .innerHTML call in order to assign HTML code to the comments element. However, this is very prone to HTML injections if the user decides to put in HTML code as a comment. As such, this change should prevent that.