### PR TITLE
Add new sort order, more CSS changes to comments page

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
+  private static final int ERROR = -1;
   private static final int TIME_DESCENDING = 0;
   private static final int TIME_ASCENDING = 1;
 
@@ -115,20 +116,20 @@ public class DataServlet extends HttpServlet {
    */
   private int getSortOrder(HttpServletRequest request) {
     String data = request.getHeader("commentSort");
-    if ("timeAscending".equals(data)) {
+    if (data.equals("timeAscending")) {
       return TIME_ASCENDING;
-    } else if ("timeDescending".equals(data)) {
+    } else if (data.equals("timeDescending")) {
       return TIME_DESCENDING;
     } else {
-      return -1;
+      return ERROR;
     }
   }
 
   /**
-   * @return true if the fields need to be updated, false otherwise
+   * @return true if the fields need to be updated, false otherwise.
    */
   private boolean getToChange(HttpServletRequest request) {
     String data = request.getHeader("change");
-    return "true".equals(data);
+    return data != null && data.equals("true");
   }
 }

--- a/portfolio/src/main/webapp/comments.html
+++ b/portfolio/src/main/webapp/comments.html
@@ -27,15 +27,30 @@
   <h1>Comments</h1>
   <div id="htmlforms">
     <form action="/data" method="POST">
-      <input type="text"  name="username" />
-      <textarea name="comment">Enter your comment here</textarea>
+      <label for:"name">Username</label>
+      <br/>
+      <input type="text" name="username" id="name"/>
+      <br/><br/>
+      <label for:"comment">Enter your comment here:</label>
+      <br/>
+      <textarea name="comment" id="comment"></textarea>
+      <br/><br/>
       <input type="submit" />
       <br/><br/>
     </form>
     <div id="numComments">
-      <a href="comments.html?numComments=5">5</a>
-      <a href="comments.html?numComments=10">10</a>
-      <a href="comments.html?numComments=25">25</a>
+      <button onclick="addParameter('numComments', 5); getMessage();">5</button>
+      <button onclick="addParameter('numComments', 10); getMessage();">10</button>
+      <button onclick="addParameter('numComments', 25); getMessage();">25</button>
+    </div>
+    <br/><br/>
+    <div class="commentSort">
+      <label for="commentSort">Sort By</label>
+      <select id="commentSort" onchange="reorder()">
+        <option disabled selected value> -- Select an option -- </option>
+        <option value="timeAscending">Oldest</option>
+        <option value="timeDescending">Newest</option>
+      </select>
     </div>
     <br/>
     <div id="display-comments"></div>

--- a/portfolio/src/main/webapp/comments.html
+++ b/portfolio/src/main/webapp/comments.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <script src="script.js"></script>
 </head>
-<body onload="getMessage()">
+<body onload="initMessages()">
   <div class="topnav">
     <a href="index.html">Home</a>
     <a href="gallery.html">LightScape Gallery</a>
@@ -39,17 +39,17 @@
       <br/><br/>
     </form>
     <div id="numComments">
-      <button onclick="addParameter('numComments', 5); getMessage();">5</button>
-      <button onclick="addParameter('numComments', 10); getMessage();">10</button>
-      <button onclick="addParameter('numComments', 25); getMessage();">25</button>
+      <button onclick="addParameter('numComments', 5); updateMessage();">5</button>
+      <button onclick="addParameter('numComments', 10); updateMessage();">10</button>
+      <button onclick="addParameter('numComments', 25); updateMessage();">25</button>
     </div>
     <br/><br/>
     <div class="commentSort">
       <label for="commentSort">Sort By</label>
-      <select id="commentSort" onchange="reorder()">
-        <option disabled selected value> -- Select an option -- </option>
-        <option value="timeAscending">Oldest</option>
+      <select id="commentSort" onchange="getOrder(); updateMessage();">
+        <option disabled selected>Sort By</option>
         <option value="timeDescending">Newest</option>
+        <option value="timeAscending">Oldest</option>
       </select>
     </div>
     <br/>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -57,7 +57,7 @@ function initMessages() {
 }
 
 /**
- * Insert all messages from the given list into a new div on the page
+ * Insert all messages from the given list into a new div on the page.
  */
 function getMessages(messages) {
     console.log(messages);
@@ -66,9 +66,9 @@ function getMessages(messages) {
     let commentsDiv = document.createElement('div');
 
     let sortNum = messages[messages.length - 1];
-    let colonIndex = sortNum.indexOf(";");
-    let sortOrder = sortNum.substring(colonIndex + 1, sortNum.length);
-    addParameter('numComments', sortNum.substring(0, colonIndex));
+    let semicolonIndex = sortNum.indexOf(";");
+    let sortOrder = sortNum.substring(semicolonIndex + 1, sortNum.length);
+    addParameter('numComments', sortNum.substring(0, semicolonIndex));
     addParameter('commentSort', sortOrder);
 
     section.innerHTML = '';
@@ -93,8 +93,7 @@ function addComment(commentsDiv, messages, index) {
 
 function deleteMessages() {
   fetch('/delete-data', {method: 'POST'}).then(() => {
-    document.getElementById('display-comments').innerHTML = 
-        '<p>Nothing to see here!</p><br/>';
+    document.getElementById('display-comments').innerHTML = '';
   });
 }
 
@@ -117,7 +116,7 @@ function addParameter(name, value) {
 }
 
 /**
- * Reorder the messages in the order selected by the user
+ * Reorder the messages in the order selected by the user.
  */
 function getOrder() {
   let select = document.getElementById('commentSort');

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var order = "timeDescending";
-
 /**
  * Adds a random greeting to the page.
  */
@@ -38,33 +36,49 @@ function addRandomGreeting() {
 }
 
 /**
+ * Updates the sort order and number of comments to display in the server,
+ * and fetches them according to the new parameters.
+ */
+function updateMessage() {
+  let headers = new Headers();
+  headers.append('numComments', getParameter('numComments'));
+  headers.append('commentSort', getParameter('commentSort'));
+  headers.append('change', true);
+
+  fetch('/data', {headers: headers}).then(response => response.json()).then((messages) => 
+      getMessages(messages));
+}
+
+/**
  * Fetches the message from the servlet and displays it on the page.
  */
-function getMessage() {
-  fetch('/data').then(response => response.json()).then((messages) => {
+function initMessages() {
+  fetch('/data').then(response => response.json()).then((messages) => getMessages(messages));
+}
+
+/**
+ * Insert all messages from the given list into a new div on the page
+ */
+function getMessages(messages) {
     console.log(messages);
 
     let section = document.getElementById('display-comments');
     let commentsDiv = document.createElement('div');
-    let numDisplay = getParameter("numComments");
-    if (numDisplay == null) {
-      numDisplay = 10;  // Default value.
-    }
+
+    let sortNum = messages[messages.length - 1];
+    let colonIndex = sortNum.indexOf(";");
+    let sortOrder = sortNum.substring(colonIndex + 1, sortNum.length);
+    addParameter('numComments', sortNum.substring(0, colonIndex));
+    addParameter('commentSort', sortOrder);
 
     section.innerHTML = '';
 
     // Order the comments appropriately. Default value is by newest.
-    if (order === "timeAscending") {
-      for (index = messages.length - 1; index >= 0 && index >= messages.length - numDisplay; index--) {
-        addComment(commentsDiv, messages, index);  
-       }
-    } else {
-      for (index = 0; index < messages.length && index < numDisplay; index++) {
-        addComment(commentsDiv, messages, index);
-      }
+    for (index = 0; index < messages.length - 1; index++) {
+      addComment(commentsDiv, messages, index);
     }
     section.appendChild(commentsDiv);
-  });
+
 }
 
 /**
@@ -72,11 +86,9 @@ function getMessage() {
  */
 function addComment(commentsDiv, messages, index) {
   let comment = document.createElement('p');
-  let linebreak = document.createElement('br');
   comment.textContent = messages[index];
 
   commentsDiv.appendChild(comment);
-  commentsDiv.appendChild(linebreak);
 }
 
 function deleteMessages() {
@@ -107,9 +119,7 @@ function addParameter(name, value) {
 /**
  * Reorder the messages in the order selected by the user
  */
-function reorder() {
+function getOrder() {
   let select = document.getElementById('commentSort');
-  order = select.options[select.selectedIndex].value;
-  console.log(order);
-  getMessage();
+  addParameter('commentSort', select.options[select.selectedIndex].value);
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+var order = "timeDescending";
+
 /**
  * Adds a random greeting to the page.
  */
@@ -41,21 +43,40 @@ function addRandomGreeting() {
 function getMessage() {
   fetch('/data').then(response => response.json()).then((messages) => {
     console.log(messages);
+
+    let section = document.getElementById('display-comments');
     let commentsDiv = document.createElement('div');
     let numDisplay = getParameter("numComments");
     if (numDisplay == null) {
       numDisplay = 10;  // Default value.
     }
-    for (index = 0; index < messages.length && index < numDisplay; index++) {
-      let comment = document.createElement('p');
-      let linebreak = document.createElement('br');
-      comment.textContent = messages[index];
 
-      commentsDiv.appendChild(comment);
-      commentsDiv.appendChild(linebreak);
+    section.innerHTML = '';
+
+    // Order the comments appropriately. Default value is by newest.
+    if (order === "timeAscending") {
+      for (index = messages.length - 1; index >= 0 && index >= messages.length - numDisplay; index--) {
+        addComment(commentsDiv, messages, index);  
+       }
+    } else {
+      for (index = 0; index < messages.length && index < numDisplay; index++) {
+        addComment(commentsDiv, messages, index);
+      }
     }
-    document.getElementById('display-comments').appendChild(commentsDiv);
+    section.appendChild(commentsDiv);
   });
+}
+
+/**
+ * Adds a comment/message at the given index in the messages list into the comments div.
+ */
+function addComment(commentsDiv, messages, index) {
+  let comment = document.createElement('p');
+  let linebreak = document.createElement('br');
+  comment.textContent = messages[index];
+
+  commentsDiv.appendChild(comment);
+  commentsDiv.appendChild(linebreak);
 }
 
 function deleteMessages() {
@@ -71,4 +92,24 @@ function deleteMessages() {
 function getParameter(name) {
   const urlParams = new URLSearchParams(window.location.search);
   return urlParams.get(name);
+}
+
+/**
+ * Adds a parameter with the given name and value to the query URL.
+ */
+function addParameter(name, value) {
+  const urlParams = new URLSearchParams(window.location.search);
+  urlParams.set(name, value);
+  let newQuery = window.location.pathname + '?' + urlParams.toString();
+  history.pushState(null, '', newQuery);
+}
+
+/**
+ * Reorder the messages in the order selected by the user
+ */
+function reorder() {
+  let select = document.getElementById('commentSort');
+  order = select.options[select.selectedIndex].value;
+  console.log(order);
+  getMessage();
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -99,18 +99,24 @@ h1 {
   margin-left: 20px;
 }
 
-#numComments a {
+#numComments button {
   text-decoration: none;
   background-color: #333;
   color: white;
-  padding: 6px 8px;
+  padding: 8px 8px;
   text-align: left;
   display: block;
   float: left;
 }
 
-#numComments a:hover {
+#numComments button:hover {
   background-color: #32C7BD;
+}
+
+.commentsOrder {
+  float: left;
+  display: inline-block;
+  margin-left: 20px;
 }
 
 #display-comments {
@@ -119,6 +125,16 @@ h1 {
   padding: 8px 8px;
   text-align: left;
   margin-left: 20px;
+}
+
+#display-comments p {
+  padding: 8px 8px;
+  display: block;
+  background-color: #111;
+}
+
+#display-comments p:hover {
+  background-color: #101010;
 }
 
 #quotes {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -131,7 +131,7 @@ h1 {
 #display-comments p {
   margin: 20px 20px;
   padding: 16px 16px;
-  width: 100%;
+  width: 700px;
   display: block;
   background-color: #333;
   box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -100,6 +100,7 @@ h1 {
 }
 
 #numComments button {
+  border: none;
   text-decoration: none;
   background-color: #333;
   color: white;
@@ -122,15 +123,18 @@ h1 {
 #display-comments {
   display: block;
   color: white;
-  padding: 8px 8px;
+  padding: 16px 16px;
   text-align: left;
   margin-left: 20px;
 }
 
 #display-comments p {
-  padding: 8px 8px;
+  margin: 20px 20px;
+  padding: 16px 16px;
+  width: 100%;
   display: block;
-  background-color: #111;
+  background-color: #333;
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
 }
 
 #display-comments p:hover {


### PR DESCRIPTION
There is a problem, however, with the sort order and how many comments are displayed on the page. Since all of that is currently client-side, whenever the user posts a new comment and gets redirected, both the sort order and how many comments are displayed on the page are set back to their default values. Perhaps moving these features to more server-side would resolve this issue, but I have not yet figured out how to successfully implement this.

The page still needs some CSS work as well, so that is something I will definitely get busy on as well.